### PR TITLE
add a workflow for packaging it as a zip xd

### DIFF
--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -1,0 +1,45 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the bash branch
+  push:
+    tags: [ '*' ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  release:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      # Runs a set of commands using the runners shell
+      - name: zip it
+        uses: tuxecure/zip-it@v2.3
+        with:
+          pkg_directories: bin config share
+          bin: jerk
+          config: components
+          data_directory: BlockOTA.jerk
+          package_name: jerk
+
+      - name: setup release
+        uses: spenserblack/actions-tag-to-release@master
+
+      - name: Make release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: jerk.zip


### PR DESCRIPTION
Alright, this should do it
This enables installations with
```
wget https://github.com/kugiigi/jerk-installer/releases/latest/download/jerk.zip -O ~/Downloads/jerk.zip
unzip ~/Downloads/jerk.zip -d ~/jerk
~/jerk/jerk setup
```
removal with
```
source ~/.local/lib/crackle/jerk
remove_jerk
```
And even upgrades with
```
source ~/.local/lib/crackle/jerk
download_jerk
unzip_jerk
install_jerk
```

The worflow it self consists of 4 actions
- the first one checks out the code (git checkout)
- the second one is zip-it
- the third one creates a github release based on the latest tag
- the fourth one uploads the package to the github release

The third action actually works with annotated tags

tags are like commits but without a commit hisiory
With say `git tag v1.0` the latest commit gets a tag `v1.0` this means when you do `git checkout v1.0` you get exactly that commit and nothing else

With `git -a v1.0` you create an annotated tag. Just like with commits you get to type a message for the tag. And just like with commits the format is as follows:
```
$short_description

$long_multiline_description
```
The third action take advantage of this, it uses $short_description as the title of the github release and $long_multiline_description as the release notes
A nice example can be seen here: https://github.com/Fuseteam/sshmount/releases/tag/v1.0
Where `sshmount v1.0` is the `$short_description` and the rest is `$long_multiline_description`

Long story short:
You can do `git tag -a v0.1` to write out the github release title and release notes and run `git push --follow-tags` to make a release ;)

If anything's unclear feel free to ping me~